### PR TITLE
Address comments from legal team

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,43 +1,82 @@
 # Contributing
 
-Thank you for your interest in contributing to glTFast! We are
-incredibly excited to see how members of our community will use and extend
-glTFast. To facilitate your contributions, we've outlined a brief set
-of guidelines to ensure that your extensions can be easily integrated.
+Thank you for your interest in contributing to glTFast!
 
-## Communication
+Here are our guidelines for contributing:
 
-First, please read through our [code of conduct](CODE_OF_CONDUCT.md), as we
-expect all our contributors to follow it.
-
-Second, before starting on a project that you intend to contribute in any form, we
-**strongly** recommend posting on our
-[Issues page](https://github.com/atteneder/glTFast/issues) and
-briefly outline the changes you plan to make. This will enable us to provide
-some context that may be helpful for you. This could range from advice and
-feedback on how to optimally perform your changes or reasons for not doing it.
-
-Lastly, if you're looking for input on what to contribute browse the GitHub
-issues, especially ones with the `help wanted` or `good first issue` label.
+* [Code of Conduct](#coc)
+* [Ways to Contribute](#ways)
+  * [Issues and Bugs](#issue)
+  * [Feature Requests](#feature)
+  * [Improving Documentation](#docs)
+* [Unity Contribution Agreement](#cla)
+* [Pull Request Submission Guidelines](#submit-pr)
 
 
-## Git Branches
+## <a name="coc"></a> Code of Conduct
 
-The main branch corresponds to the most recent version of the project. Note
-that this branch may be unstable and may be newer that the latest release.
+Please help us keep glTFast open and inclusive. Read and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 
-When contributing to the project, please make sure that your Pull Request (PR)
-contains the following:
+## <a name="ways"></a> Ways to Contribute
 
-- Detailed description of the changes performed
-- Corresponding changes to documentation, changelog and unit tests
-- Summary of the tests performed to validate your changes
-- Issue numbers that the PR resolves (if any)
+There are many ways in which you can contribute to glTFast.
 
-## Contributor License Agreements
+### <a name="issue"></a> Issues and Bugs
 
-When you open a pull request, you will be asked to acknolwedge our Contributor
-License Agreement. You will have to confirm that your Contributions are your
-original creation and that you have complete right and authority to make your
-Contributions. We allow both individual contributions and contributions made on
-behalf of companies. 
+If you find a bug in the source code, you can help us by submitting an issue to our
+GitHub Repository. Even better, you can submit a Pull Request with a fix.
+
+### <a name="feature"></a> Feature Requests
+
+You can request a new feature by submitting an issue to our GitHub Repository.
+
+If you would like to implement a new feature then consider what kind of change it is:
+
+* `Major Changes` that you wish to contribute to the project should be discussed first with other developers. Submit your ideas as an issue.
+
+* `Small Changes` can be directly submitted to the GitHub Repository
+  as a Pull Request. See the section about [Pull Request Submission Guidelines](#submit-pr).
+
+### <a name="docs"></a> Documentation
+
+We accept changes and improvements to our documentation. Just submit a Pull Request with your proposed changes as described in the [Pull Request Submission Guidelines](#submit-pr).
+
+
+## <a name="cla"></a> All contributions are subject to the [Unity Contribution Agreement(UCA)](https://unity3d.com/legal/licenses/Unity_Contribution_Agreement)
+
+By making a pull request, you are confirming agreement to the terms and conditions of the UCA, including that your Contributions are your original creation and that you have complete right and authority to make your Contributions.
+
+## <a name="submit-pr"></a> Pull Request Submission Guidelines
+
+We use the [Gitflow Workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) for the development of glTFast. This means development happens on the **unity branch** and Pull Requests should be submited to it.
+
+### <a name="branch"></a> Branch Name Prefix
+  - `bug/` Fixing a bug
+  - `feature/` New feature implementation
+  - `perf/` Performance improvement
+  - `refactor/` A code change that neither fixes a bug nor adds a feature
+  - `doc/` Added documentation
+  - `test/` Added Unit Tests
+  - `build/` Changes that affect the build system or external dependencies
+  - `ci/` Changes to our CI configuration files and scripts
+  - `style/` Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+
+### Requirements
+  - The branch name has the respective [prefix](#branch).
+  - [Changelog](CHANGELOG.md) entry added under `Unreleased` section.
+    - Explains the change in `Modified`, `Fixed`, `Added` sections.
+    - For API change contains an example snippet and/or migration example.
+    - If UI or rendering results applies, include screenshots.
+    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
+    - FogBugz is marked as `Resolved` with `next` release version correctly set.
+  - Tests added/changed, if applicable.
+    - Functional tests.
+    - Performance tests.
+    - Integration tests.
+  - All Tests passed.
+  - Documentation was added for new/changed.
+    - XmlDoc cross references are set correctly.
+    - Added explanation how the API works.
+    - Usage code examples added.
+  - Coding Standards are respected.
+  - Rebase the branch if possible.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,7 @@
-glTF for Unity copyright © 2021 Unity Technologies ApS
-
-Licensed under the Unity Companion License for Unity-dependent projects--see [Unity Companion License](http://www.unity3d.com/legal/licenses/Unity_Companion_License). 
-
-Unless expressly provided otherwise, the Software under this license is made available strictly on an "AS IS" BASIS WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED. Please review the license for details on these and other terms and conditions.
+Copyright 2019 Andreas Atteneder
+ 
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ 
+	http://www.apache.org/licenses/LICENSE-2.0
+ 
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.”

--- a/README.md
+++ b/README.md
@@ -132,27 +132,6 @@ Contributions in the form of ideas, comments, critique, bug reports, pull reques
 
 Thanks to [Embibe][embibe] for sponsoring the development of skin support! ❤️
 
-## License
-
-Copyright (c) 2020-2022 Andreas Atteneder, All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use files in this repository except in compliance with the License.
-You may obtain a copy of the License at
-
-   <http://www.apache.org/licenses/LICENSE-2.0>
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-## Trademarks
-
-*Unity* is a registered trademark of [Unity Technologies][unity].
-
-*Khronos®* is a registered trademark and *glTF™* is a trademark of [The Khronos Group Inc][khronos].
 
 [embibe]: https://www.embibe.com
 [DracoUnity]: https://github.com/atteneder/DracoUnity

--- a/Third Party Notices.md
+++ b/Third Party Notices.md
@@ -1,22 +1,11 @@
 This package contains third-party software components governed by the license(s) indicated below:
 ---------
 
-Component Name: [glTFast][gltfast]
+## Trademarks
 
-License Type: Apache 2.0
+*Unity* is a registered trademark of [Unity Technologies][unity].
 
-Copyright 2020-2022 Andreas Atteneder
+*Khronos®* is a registered trademark and *glTF™* is a trademark of [The Khronos Group Inc][khronos].
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-[gltfast]: https://github.com/atteneder/glTFast
+[unity]: https://unity.com
+[khronos]: https://www.khronos.org


### PR DESCRIPTION
Move licensing from andreas/unity being a third party license embedded into a Unity license to the entire repository simply being under the original apache license.